### PR TITLE
Placeholder fixes

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.h
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.h
@@ -14,6 +14,7 @@
 #define MSG_SET_VISIBLE @"SetVisible"
 #define MSG_TEXT_CHANGE @"TextChange"
 #define MSG_TEXT_END_EDIT @"TextEndEdit"
+#define MSG_RETURN_PRESSED @"ReturnPressed"
 
 @interface EditBoxHoldView : UIView
 {

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -306,6 +306,17 @@ bool approxEqualFloat(float x, float y)
         keyboardDoneButtonView = nil;
     }
     
+    UIReturnKeyType returnKeyType = UIReturnKeyDefault;
+    string returnKeyTypeString = [json getString:@"return_key_type"];
+    if ([returnKeyTypeString isEqualToString:@"Next"])
+    {
+        returnKeyType = UIReturnKeyNext;
+    }
+    if ([returnKeyTypeString isEqualToString:@"Done"])
+    {
+        returnKeyType = UIReturnKeyDone;
+    }
+    
     if (multiline)
     {
         PlaceholderTextView* textView = [[PlaceholderTextView alloc] initWithFrame:CGRectMake(x, y, width, height)];
@@ -319,7 +330,7 @@ bool approxEqualFloat(float x, float y)
         
         textView.textColor = [UIColor colorWithRed:textColor_r green:textColor_g blue:textColor_b alpha:textColor_a];
         textView.backgroundColor =[UIColor colorWithRed:backColor_r green:backColor_g blue:backColor_b alpha:backColor_a];
-        textView.returnKeyType = UIReturnKeyDefault;
+        textView.returnKeyType = returnKeyType;
         textView.autocorrectionType = autoCorr ? UITextAutocorrectionTypeYes : UITextAutocorrectionTypeNo  ;
         textView.contentInset = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f);
         textView.placeholder = placeholder;
@@ -344,7 +355,7 @@ bool approxEqualFloat(float x, float y)
         textField.text = @"";
         textField.textColor = [UIColor colorWithRed:textColor_r green:textColor_g blue:textColor_b alpha:textColor_a];
         textField.backgroundColor =[UIColor colorWithRed:backColor_r green:backColor_g blue:backColor_b alpha:backColor_a];
-        textField.returnKeyType = UIReturnKeyDefault;
+        textField.returnKeyType = returnKeyType;
         textField.autocorrectionType = autoCorr ? UITextAutocorrectionTypeYes : UITextAutocorrectionTypeNo;
         textField.contentVerticalAlignment = valign;
         textField.contentHorizontalAlignment = halign;

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -464,6 +464,16 @@ bool approxEqualFloat(float x, float y)
     [self onTextEditEnd:textView.text];
 }
 
+- (BOOL)textFieldShouldReturn:(UITextField *)textField
+{
+    if (![editView isFirstResponder]) return YES;
+    JsonObject* jsonToUnity = [[JsonObject alloc] init];
+    
+    [jsonToUnity setString:@"msg" value:MSG_RETURN_PRESSED];
+    [self sendJsonToUnity:jsonToUnity];
+    return YES;
+}
+
 -(void) textFieldDidChange :(UITextField *)theTextField{
     [self onTextChange:theTextField.text];
 }

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -8,6 +8,7 @@
 UIViewController* unityViewController = nil;
 NSMutableDictionary*    dictEditBox = nil;
 EditBoxHoldView*         viewPlugin = nil;
+NSString* placeholder = nil;
 
 #define DEF_PixelPerPoint 2.2639f // 72 points per inch. iPhone 163DPI
 char    g_unityName[64];
@@ -179,7 +180,7 @@ bool approxEqualFloat(float x, float y)
 
 -(void) create:(JsonObject*)json
 {
-    NSString* placeholder = [json getString:@"placeHolder"];
+    placeholder = [json getString:@"placeHolder"];
     
     NSString* font = [json getString:@"font"];
     float fontSize = [json getFloat:@"fontSize"];
@@ -489,8 +490,13 @@ bool approxEqualFloat(float x, float y)
     [self onTextChange:theTextField.text];
 }
 
+- (void)textFieldDidBeginEditing:(UITextField *)textField {
+    textField.placeholder = nil;
+}
+
 -(void) textFieldDidEndEditing:(UITextField *)textField
 {
+    textField.placeholder = placeholder;
     [self onTextEditEnd:textField.text];
 }
 

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -49,7 +49,10 @@ public class NativeEditBox : PluginMsgReceiver {
 		public string placeHolder;
 	}
 
+	public enum ReturnKeyType { Default, Next, Done };
+
 	public bool	withDoneButton = true;
+	public ReturnKeyType iosReturnKeyType;
 	public event Action iosReturnPressed; 
 
 	private bool	bNativeEditCreated = false;
@@ -251,6 +254,24 @@ public class NativeEditBox : PluginMsgReceiver {
 		jsonMsg["withDoneButton"] = this.withDoneButton;
 		jsonMsg["placeHolder"] = mConfig.placeHolder;
 		jsonMsg["multiline"] = mConfig.multiline;
+
+		switch (iosReturnKeyType)
+		{
+			case ReturnKeyType.Default:
+				jsonMsg["return_key_type"] = "Default";
+				break;
+
+			case ReturnKeyType.Next:
+				jsonMsg["return_key_type"] = "Next";
+				break;
+
+			case ReturnKeyType.Done:
+				jsonMsg["return_key_type"] = "Done";
+				break;
+
+			default:
+				break;
+		}
 
 		JsonObject jsonRet = this.SendPluginMsg(jsonMsg);
 		bNativeEditCreated = !this.CheckErrorJsonRet(jsonRet);

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -32,6 +32,7 @@
 
 
 using UnityEngine;
+using System;
 using System.Collections;
 using UnityEngine.UI;
 
@@ -49,6 +50,7 @@ public class NativeEditBox : PluginMsgReceiver {
 	}
 
 	public bool	withDoneButton = true;
+	public event Action iosReturnPressed; 
 
 	private bool	bNativeEditCreated = false;
 
@@ -65,6 +67,7 @@ public class NativeEditBox : PluginMsgReceiver {
 	private static string MSG_TEXT_CHANGE = "TextChange";
 	private static string MSG_TEXT_END_EDIT = "TextEndEdit";
 	private static string MSG_ANDROID_KEY_DOWN = "AndroidKeyDown"; // to fix bug Some keys 'back' & 'enter' are eaten by unity and never arrive at plugin
+	private static string MSG_RETURN_PRESSED = "ReturnPressed";
 
 	public static Rect GetScreenRectFromRectTransform(RectTransform rectTransform)
 	{
@@ -201,6 +204,11 @@ public class NativeEditBox : PluginMsgReceiver {
 		{
 			string text = jsonMsg.GetString("text");
 			this.onTextEditEnd(text);
+		}
+		else if (msg.Equals(MSG_RETURN_PRESSED))
+		{
+			if (iosReturnPressed != null)
+				iosReturnPressed();
 		}
 	}
 

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -147,6 +147,7 @@ public class NativeEditBox : PluginMsgReceiver {
 		this.CreateNativeEdit();
 		this.SetTextNative(this.objUnityText.text);
 
+		objUnityInput.placeholder.gameObject.SetActive(false);
 		objUnityText.enabled = false;
 		objUnityInput.enabled = false;
 		#endif
@@ -165,15 +166,11 @@ public class NativeEditBox : PluginMsgReceiver {
 			Debug.LogErrorFormat("No InputField found {0} NativeEditBox Error", this.name);
 			throw new MissingComponentException();
 		}
-		objUnityText = objUnityInput.textComponent;		
-
-		// There seems to be an issue with the native placeholder where both the native and Unity placeholders are
-		// displayed at the same time if some input text is entered and then deleted.
-		//
-		// Currently we are using the Unity placeholder, which only gets hidden when the user starts typing (not on
-		// focus). This is what we want for our usecase, but this should be revisited if standard placeholder behaviour
-		// is wanted.
-		mConfig.placeHolder = "";
+		
+		Graphic placeHolder = objUnityInput.placeholder;
+		objUnityText = objUnityInput.textComponent;
+		
+		mConfig.placeHolder = placeHolder.GetComponent<Text>().text;
 		mConfig.font = objUnityText.font.fontNames.Length > 0 ? objUnityText.font.fontNames[0] : "Arial";
 
 		Rect rectScreen = GetScreenRectFromRectTransform(this.objUnityText.rectTransform);

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -146,8 +146,7 @@ public class NativeEditBox : PluginMsgReceiver {
 		#if (UNITY_IPHONE || UNITY_ANDROID) &&!UNITY_EDITOR
 		this.CreateNativeEdit();
 		this.SetTextNative(this.objUnityText.text);
-		
-		objUnityInput.placeholder.enabled = false;
+
 		objUnityText.enabled = false;
 		objUnityInput.enabled = false;
 		#endif
@@ -166,11 +165,15 @@ public class NativeEditBox : PluginMsgReceiver {
 			Debug.LogErrorFormat("No InputField found {0} NativeEditBox Error", this.name);
 			throw new MissingComponentException();
 		}
-		
-		Graphic placeHolder = objUnityInput.placeholder;
-		objUnityText = objUnityInput.textComponent;
-		
-		mConfig.placeHolder = placeHolder.GetComponent<Text>().text;
+		objUnityText = objUnityInput.textComponent;		
+
+		// There seems to be an issue with the native placeholder where both the native and Unity placeholders are
+		// displayed at the same time if some input text is entered and then deleted.
+		//
+		// Currently we are using the Unity placeholder, which only gets hidden when the user starts typing (not on
+		// focus). This is what we want for our usecase, but this should be revisited if standard placeholder behaviour
+		// is wanted.
+		mConfig.placeHolder = "";
 		mConfig.font = objUnityText.font.fontNames.Length > 0 ? objUnityText.font.fontNames[0] : "Arial";
 
 		Rect rectScreen = GetScreenRectFromRectTransform(this.objUnityText.rectTransform);


### PR DESCRIPTION
This happened if text was first entered and then deleted. Fix by displaying only the Unity placeholder.

Also hide/display the placeholder on change of focus instead of when the user starts typing or empties the field.