### PR TITLE
Remove native input field on destroy

### DIFF
--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -114,6 +114,8 @@ public class NativeEditBox : PluginMsgReceiver {
 
 	protected new void OnDestroy()
 	{
+		RemoveNative();
+
 		base.OnDestroy();
 	}
 


### PR DESCRIPTION
It used to just get hidden, which is bad in itself and also caused
a crash when instantiating a new one, because the NativeEditBox
instance was cleared on destruction from the m_dictReceiver on
PluginMsgHandler. When a new NativeEditBox was instantiated
the old hidden one sent an EndEditing message, because focus
was moved to the new NativeEditBox, but the receiver id could not
be found on the dictionary anymore.