### PR TITLE
Fix duplicate text changed event

### DIFF
--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -206,6 +206,13 @@ public class NativeEditBox : PluginMsgReceiver {
 
 	private void onTextChange(string newText)
 	{
+		bool didTextChange = newText == this.objUnityInput.text;
+
+		// Avoid firing a delayed onValueChanged event if the text was changed from Unity with the text property in this
+		// class.
+		if (!didTextChange)
+			return;
+		
 		this.objUnityInput.text = newText;
 		if (this.objUnityInput.onValueChanged != null) this.objUnityInput.onValueChanged.Invoke(newText);
 	}

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -205,12 +205,10 @@ public class NativeEditBox : PluginMsgReceiver {
 	}
 
 	private void onTextChange(string newText)
-	{
-		bool didTextChange = newText != this.objUnityInput.text;
-
+	{		
 		// Avoid firing a delayed onValueChanged event if the text was changed from Unity with the text property in this
 		// class.
-		if (!didTextChange)
+		if (newText == this.objUnityInput.text)
 			return;
 		
 		this.objUnityInput.text = newText;

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -206,7 +206,7 @@ public class NativeEditBox : PluginMsgReceiver {
 
 	private void onTextChange(string newText)
 	{
-		bool didTextChange = newText == this.objUnityInput.text;
+		bool didTextChange = newText != this.objUnityInput.text;
 
 		// Avoid firing a delayed onValueChanged event if the text was changed from Unity with the text property in this
 		// class.


### PR DESCRIPTION
Duplicate onValueChanged event when the text was modified from Unity should be fixed.