### PR TITLE
Fix too big font on iOS

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -323,10 +323,7 @@ bool approxEqualFloat(float x, float y)
         returnKeyType = UIReturnKeyDone;
     }
     
-    CGRect screenRect = [[UIScreen mainScreen] bounds];
-    CGFloat screenWidth = screenRect.size.width;
-    CGFloat logicalScreenWidth = screenWidth / viewPlugin.contentScaleFactor;
-    fontSize = (logicalScreenWidth / 1024.0f) * fontSize;
+    fontSize = fontSize / viewPlugin.contentScaleFactor;
     
     UIFont* uiFont;
     if ([font length] > 0)

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -323,7 +323,8 @@ bool approxEqualFloat(float x, float y)
         returnKeyType = UIReturnKeyDone;
     }
     
-    fontSize = fontSize / viewPlugin.contentScaleFactor;
+    // Conversion for retina displays
+    fontSize = fontSize / [UIScreen mainScreen].scale;
     
     UIFont* uiFont;
     if ([font length] > 0)

--- a/release/NativeEditPlugin/demo/demo.unity
+++ b/release/NativeEditPlugin/demo/demo.unity
@@ -122,8 +122,8 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000012397999, y: 69.400024}
-  m_SizeDelta: {x: 408.7, y: 32.8}
+  m_AnchoredPosition: {x: -1, y: -87}
+  m_SizeDelta: {x: 563, y: 48}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &81037574
 MonoBehaviour:
@@ -370,11 +370,11 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 35
+    m_FontSize: 45
     m_FontStyle: 2
     m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
+    m_MinSize: 4
+    m_MaxSize: 45
     m_Alignment: 0
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -423,8 +423,8 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.45001, y: -5}
-  m_SizeDelta: {x: 420, y: 46}
+  m_AnchoredPosition: {x: 2, y: -93}
+  m_SizeDelta: {x: 578, y: 67}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &304998751
 MonoBehaviour:
@@ -611,7 +611,7 @@ MonoBehaviour:
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1000, y: 563}
+  m_ReferenceResolution: {x: 1334, y: 750}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -693,10 +693,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 22
+    m_FontSize: 35
     m_FontStyle: 2
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 3
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -865,8 +865,8 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.45001, y: 0.00000047683716}
-  m_SizeDelta: {x: 420, y: 46}
+  m_AnchoredPosition: {x: 2, y: -131}
+  m_SizeDelta: {x: 578, y: 67}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &701725106
 MonoBehaviour:
@@ -882,6 +882,12 @@ MonoBehaviour:
   withDoneButton: 1
   returnKeyType: 0
   updateRectEveryFrame: 0
+  useInputFieldFont: 0
+  OnReturnPressed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
 --- !u!1 &714599577
 GameObject:
   m_ObjectHideFlags: 0
@@ -914,7 +920,7 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -4, y: -234}
+  m_AnchoredPosition: {x: 1, y: -149}
   m_SizeDelta: {x: -83, y: 109}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &764202633
@@ -949,7 +955,7 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -4, y: -135}
+  m_AnchoredPosition: {x: 1, y: -50}
   m_SizeDelta: {x: -83, y: 109}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &922060701
@@ -1223,8 +1229,8 @@ RectTransform:
   m_RootOrder: 3
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 1.75, y: -56}
-  m_SizeDelta: {x: -74.5, y: 58}
+  m_AnchoredPosition: {x: 5, y: -104}
+  m_SizeDelta: {x: 400, y: 85}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1102460062
 MonoBehaviour:
@@ -1297,7 +1303,7 @@ RectTransform:
   m_RootOrder: 2
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -8, y: -357}
+  m_AnchoredPosition: {x: -3, y: -272}
   m_SizeDelta: {x: -90, y: 180}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1383200500
@@ -1334,8 +1340,8 @@ RectTransform:
   m_RootOrder: 5
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -96, y: -482}
-  m_SizeDelta: {x: 85, y: 49}
+  m_AnchoredPosition: {x: -90, y: -644}
+  m_SizeDelta: {x: 117, y: 72}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1383200502
 MonoBehaviour:
@@ -1478,11 +1484,11 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 35
+    m_FontSize: 45
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
+    m_MinSize: 4
+    m_MaxSize: 45
     m_Alignment: 0
     m_AlignByGeometry: 0
     m_RichText: 0
@@ -1604,8 +1610,8 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5.2, y: 30.6}
-  m_SizeDelta: {x: 408.7, y: 32.8}
+  m_AnchoredPosition: {x: -6, y: -87}
+  m_SizeDelta: {x: 563, y: 48}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1645481299
 MonoBehaviour:
@@ -1628,10 +1634,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
+    m_FontSize: 22
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 2
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -1680,8 +1686,8 @@ RectTransform:
   m_RootOrder: 6
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -4, y: -482}
-  m_SizeDelta: {x: 85, y: 49}
+  m_AnchoredPosition: {x: 37, y: -644}
+  m_SizeDelta: {x: 117, y: 72}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1715567995
 MonoBehaviour:
@@ -1842,8 +1848,8 @@ RectTransform:
   m_RootOrder: 7
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 94, y: -482}
-  m_SizeDelta: {x: 85, y: 49}
+  m_AnchoredPosition: {x: 172, y: -644}
+  m_SizeDelta: {x: 117, y: 72}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1802371555
 MonoBehaviour:
@@ -2073,10 +2079,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 22
+    m_FontSize: 35
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 3
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -2129,10 +2135,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
+    m_FontSize: 22
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 2
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -2162,8 +2168,8 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5.2, y: 30.6}
-  m_SizeDelta: {x: 408.7, y: 32.8}
+  m_AnchoredPosition: {x: -6, y: -40}
+  m_SizeDelta: {x: 563, y: 48}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2028894513
 GameObject:
@@ -2199,8 +2205,8 @@ RectTransform:
   m_RootOrder: 4
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -188, y: -482}
-  m_SizeDelta: {x: 85, y: 49}
+  m_AnchoredPosition: {x: -216, y: -644}
+  m_SizeDelta: {x: 117, y: 72}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2028894515
 MonoBehaviour:
@@ -2323,8 +2329,8 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000015258789, y: 0}
-  m_SizeDelta: {x: 420, y: 106}
+  m_AnchoredPosition: {x: -1, y: -189}
+  m_SizeDelta: {x: 578, y: 155}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2030731845
 MonoBehaviour:
@@ -2458,6 +2464,12 @@ MonoBehaviour:
   withDoneButton: 1
   returnKeyType: 0
   updateRectEveryFrame: 0
+  useInputFieldFont: 0
+  OnReturnPressed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
 --- !u!1 &2096531381
 GameObject:
   m_ObjectHideFlags: 0
@@ -2496,10 +2508,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 22
+    m_FontSize: 35
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 3
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -2570,10 +2582,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 22
+    m_FontSize: 35
     m_FontStyle: 2
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 3
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -209,9 +209,15 @@ public class NativeEditBox : PluginMsgReceiver {
 		if (useInputFieldFont)
 			mConfig.font = objUnityText.font.fontNames.Length > 0 ? objUnityText.font.fontNames[0] : "Arial";
 
+
+		// Font size scaling for iOS is done on the native side.
+		#if UNITY_IOS
+		mConfig.fontSize = ((float)objUnityText.fontSize);
+		#else
 		Rect rectScreen = GetScreenRectFromRectTransform(this.objUnityText.rectTransform);
 		float fHeightRatio = rectScreen.height / objUnityText.rectTransform.rect.height;
 		mConfig.fontSize = ((float) objUnityText.fontSize) * fHeightRatio;
+		#endif
 
 		mConfig.textColor = objUnityText.color;
 		mConfig.align = objUnityText.alignment.ToString();

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -209,15 +209,9 @@ public class NativeEditBox : PluginMsgReceiver {
 		if (useInputFieldFont)
 			mConfig.font = objUnityText.font.fontNames.Length > 0 ? objUnityText.font.fontNames[0] : "Arial";
 
-
-		// Font size scaling for iOS is done on the native side.
-		#if UNITY_IOS
-		mConfig.fontSize = ((float)objUnityText.fontSize);
-		#else
 		Rect rectScreen = GetScreenRectFromRectTransform(this.objUnityText.rectTransform);
 		float fHeightRatio = rectScreen.height / objUnityText.rectTransform.rect.height;
 		mConfig.fontSize = ((float) objUnityText.fontSize) * fHeightRatio;
-		#endif
 
 		mConfig.textColor = objUnityText.color;
 		mConfig.align = objUnityText.alignment.ToString();


### PR DESCRIPTION
The problem with the font size was that it didn't take into account the reference resolution of the canvas scaler which was different in the demo project and our application. The size was fine in the demo project, but about 33 % too large on our application. With this fix the result should be the same as with the Unity text with any canvas scaler reference resolution.

I discovered that the iOS font scaling could actually be reduced to just dividing by the screen scaling factor.

I modified the canvas scaler in the demo scene to have the same reference resolution as our app to be able to preview the results.