### PR TITLE
Add cursor position management for programmed text changes

### DIFF
--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -385,7 +385,8 @@ public class EditBox {
 
             edit.setText(newText);
 
-            //Update text selection (cursor position) to be the same after editing text, if the user had multiple characters selected, we are losing them and get the cursor in only one position
+            // Update text selection (cursor position) to be the same after editing text
+            // If the user had multiple characters selected, we are losing them and get the cursor in only one position
             if(previousLength == cursorPos){
                 //The cursor was at the end of the text, let us put it again at the end of the text in case more characters were added
                 cursorPos = newText.length();

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -307,6 +307,7 @@ public class EditBox {
             });
 
             edit.addTextChangedListener(new TextWatcher() {
+
                 public void afterTextChanged(Editable s)
                 {
                     JSONObject jsonToUnity = new JSONObject();
@@ -332,7 +333,6 @@ public class EditBox {
                 public void beforeTextChanged(CharSequence s, int start,
                                               int count, int after) {
                     // TODO Auto-generated method stub
-
                 }
 
                 @Override
@@ -380,7 +380,22 @@ public class EditBox {
     private void SetText(String newText)
     {
         if (edit != null) {
+            int cursorPos = edit.getSelectionStart();
+            int previousLength = edit.getText().length();
+
             edit.setText(newText);
+
+            //Update text selection (cursor position) to be the same after editing text, if the user had multiple characters selected, we are losing them and get the cursor in only one position
+            if(previousLength == cursorPos){
+                //The cursor was at the end of the text, let us put it again at the end of the text in case more characters were added
+                cursorPos = newText.length();
+            }
+
+            if(cursorPos > newText.length()){
+                //Text was deleted, so cursor position is after the end of the text, let's put it at the last position
+                cursorPos = newText.length() + 1;
+            }
+            edit.setSelection(cursorPos);
         }
     }
     private String GetText()


### PR DESCRIPTION
When updating the value of the native box, the cursor jumps to position 0 so I needed to add cursor management.

My use case:
 - Some text is inserted on the box
 - In Unity code, I update the box text with a new formatted value
 - Cursor should be kept on the same position