### PR TITLE
Implemented show/hide of keyboard in the native side

### DIFF
--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -123,12 +123,6 @@ public class EditBox {
         }
     }
 
-    private void notifyVisibilityChanged(int visibility) {
-        if(visibility != View.VISIBLE) {
-            showKeyboard(false);
-        }
-    }
-
     private void processJsonMsg(JSONObject jsonMsg)
     {
         try

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -31,13 +31,15 @@ public class EditBox {
     class EditTextLifeCycle extends EditText
     {
         EditBox observerBox;
-        public EditTextLifeCycle(Context context, EditBox box) {
+        public EditTextLifeCycle(Context context, EditBox box)
+        {
             super(context);
             this.observerBox = box;
         }
 
         @Override
-        public void onWindowFocusChanged(boolean hasWindowFocus) {
+        public void onWindowFocusChanged(boolean hasWindowFocus)
+        {
             super.onWindowFocusChanged(hasWindowFocus);
             if (!hasWindowFocus)
                 observerBox.notifyFocusChanged(hasWindowFocus);
@@ -117,10 +119,10 @@ public class EditBox {
         }
     }
 
-    private void notifyFocusChanged(boolean hasWindowFocus) {
-        if(!hasWindowFocus) {
+    private void notifyFocusChanged(boolean hasWindowFocus)
+    {
+        if(!hasWindowFocus)
             showKeyboard(false);
-        }
     }
 
     private void processJsonMsg(JSONObject jsonMsg)

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -37,13 +37,6 @@ public class EditBox {
         }
 
         @Override
-        protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
-            super.onVisibilityChanged(changedView, visibility);
-            if (visibility != View.VISIBLE)
-                observerBox.notifyVisibilityChanged(visibility);
-        }
-
-        @Override
         public void onWindowFocusChanged(boolean hasWindowFocus) {
             super.onWindowFocusChanged(hasWindowFocus);
             if (!hasWindowFocus)

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -9,7 +9,6 @@ import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 
-import android.support.annotation.NonNull;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;


### PR DESCRIPTION
There is a recurrent bug in which the keyboard in not properly hidden when the application goes to the background. This is because the logic is handled from Unity. Now the native plugin takes care to hide the keyboard when the application loses the focus.