### PR TITLE
Fix crash if trying to use EditText after removal

### DIFF
--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -400,6 +400,7 @@ public class EditBox {
     {
         if (edit != null) {
             layout.removeView(edit);
+            mapEditBox.remove(this.tag);
         }
         edit = null;
     }


### PR DESCRIPTION
The mapping was not cleared so trying to send messages to the
NativeEditBox could crash the app because the EditText was null.