### PR TITLE
Don't cancel taps on iOS

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -24,6 +24,7 @@ bool approxEqualFloat(float x, float y)
     if (self = [super initWithFrame:frame])
     {
         UITapGestureRecognizer *tap=[[UITapGestureRecognizer alloc] initWithTarget:self    action:@selector(tapAction:)];
+        tap.cancelsTouchesInView = NO;
         [self addGestureRecognizer:tap];
         self.userInteractionEnabled = YES;
     }


### PR DESCRIPTION
On iOS, a GestureRecognizer is instantiated, which will capture and cancel all taps. Unity didn't use to care about this, but since 2017.2.2p2 does, so this needs to be fixed.

Fix is trivial and self-explanatory.