### PR TITLE
Fixes character limit problems

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.h
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.h
@@ -36,6 +36,8 @@
     int tag;
 }
 
+@property (nonatomic, assign) int maxLength;
+
 +(void) initializeEditBox:(UIViewController*) _unityViewController unityName:(const char*) unityName;
 +(JsonObject*) processRecvJsonMsg:(int)nSenderId msg:(JsonObject*) jsonMsg;
 +(void) finalizeEditBox;

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -10,7 +10,6 @@ NSMutableDictionary*    dictEditBox = nil;
 EditBoxHoldView*         viewPlugin = nil;
 
 char    g_unityName[64];
-int characterLimit;
 
 bool approxEqualFloat(float x, float y)
 {
@@ -203,7 +202,7 @@ bool approxEqualFloat(float x, float y)
     float width = [json getFloat:@"width"] * viewController.view.bounds.size.width;
     float height = [json getFloat:@"height"] * viewController.view.bounds.size.height;
     
-    characterLimit = [json getInt:@"characterLimit"];
+    [self setMaxLength:[json getInt:@"characterLimit"]];
     
     float textColor_r = [json getFloat:@"textColor_r"];
     float textColor_g = [json getFloat:@"textColor_g"];
@@ -566,8 +565,8 @@ bool approxEqualFloat(float x, float y)
     }
     
     NSUInteger newLength = [textField.text length] + [string length] - range.length;
-    if(characterLimit > 0)
-        return newLength <= characterLimit;
+    if([self maxLength] > 0)
+        return newLength <= [self maxLength];
     else
         return YES;
 }

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -194,7 +194,7 @@ public class NativeEditBox : PluginMsgReceiver
 		this.PrepareNativeEdit();
 		#if (UNITY_IPHONE || UNITY_ANDROID) && !UNITY_EDITOR
 		this.CreateNativeEdit();
-		this.SetTextNative(this.objUnityText.text);
+		this.SetTextNative(this.objUnityInput.text);
 
 		objUnityInput.placeholder.gameObject.SetActive(false);
 		objUnityText.enabled = false;


### PR DESCRIPTION
Stops using a global variable for the character limit.
Using a property instead.

Also uses correct text string property to avoid text cropping when initializing