### PR TITLE
Added new OnValueChanged event.

### DIFF
--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -237,16 +237,6 @@ public class NativeEditBox : PluginMsgReceiver
 		mConfig.multiline = (objUnityInput.lineType == InputField.LineType.SingleLine) ? false : true;
 	}
 
-	private void updateUnityInputText(string newText)
-	{		
-		// Avoid firing a delayed onValueChanged event if the text was changed from Unity with the text property in this
-		// class.
-		if (newText == this.objUnityInput.text)
-			return;
-		
-		this.objUnityInput.text = newText;
-	}
-
 	public override void OnPluginMsgDirect(JsonObject jsonMsg)
 	{
 		PluginMsgHandler.getInst().StartCoroutine(PluginsMessageRoutine(jsonMsg));
@@ -258,20 +248,14 @@ public class NativeEditBox : PluginMsgReceiver
 		yield return null;
 
 		string msg = jsonMsg.GetString("msg");
-		if (msg.Equals(MSG_TEXT_CHANGE))
-		{
-			string text = jsonMsg.GetString("text");
-			this.updateUnityInputText(text);
-		}
-		else if (msg.Equals(MSG_TEXT_BEGIN_EDIT))
+		if (msg.Equals(MSG_TEXT_BEGIN_EDIT))
 		{
 			if (this.OnBeginEditing != null)
 				this.OnBeginEditing.Invoke();
 		}
-		else if (msg.Equals(MSG_TEXT_END_EDIT))
+		else if (msg.Equals(MSG_TEXT_CHANGE) || msg.Equals(MSG_TEXT_END_EDIT))
 		{
-			string text = jsonMsg.GetString("text");
-			this.updateUnityInputText(text);
+			this.objUnityInput.text = jsonMsg.GetString("text");
 		}
 		else if (msg.Equals(MSG_RETURN_PRESSED))
 		{

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -70,6 +70,7 @@ public class NativeEditBox : PluginMsgReceiver
 	public bool useInputFieldFont;
 	public UnityEngine.Events.UnityEvent OnReturnPressed;
 	public UnityEngine.Events.UnityEvent OnBeginEditing;
+	public InputField.SubmitEvent OnValueChanged;
 
 	private bool bNativeEditCreated = false;
 
@@ -247,6 +248,8 @@ public class NativeEditBox : PluginMsgReceiver
 		this.objUnityInput.text = newText;
 		if (this.objUnityInput.onValueChanged != null)
 			this.objUnityInput.onValueChanged.Invoke(newText);
+
+		this.OnValueChanged?.Invoke(newText);
 	}
 
 	private void onTextEditEnd(string newText)

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -70,7 +70,6 @@ public class NativeEditBox : PluginMsgReceiver
 	public bool useInputFieldFont;
 	public UnityEngine.Events.UnityEvent OnReturnPressed;
 	public UnityEngine.Events.UnityEvent OnBeginEditing;
-	public InputField.SubmitEvent OnValueChanged;
 
 	private bool bNativeEditCreated = false;
 
@@ -238,7 +237,7 @@ public class NativeEditBox : PluginMsgReceiver
 		mConfig.multiline = (objUnityInput.lineType == InputField.LineType.SingleLine) ? false : true;
 	}
 
-	private void onTextChange(string newText)
+	private void updateUnityInputText(string newText)
 	{		
 		// Avoid firing a delayed onValueChanged event if the text was changed from Unity with the text property in this
 		// class.
@@ -246,17 +245,6 @@ public class NativeEditBox : PluginMsgReceiver
 			return;
 		
 		this.objUnityInput.text = newText;
-		if (this.objUnityInput.onValueChanged != null)
-			this.objUnityInput.onValueChanged.Invoke(newText);
-
-		this.OnValueChanged?.Invoke(newText);
-	}
-
-	private void onTextEditEnd(string newText)
-	{
-		this.objUnityInput.text = newText;
-		if (this.objUnityInput.onEndEdit != null)
-			this.objUnityInput.onEndEdit.Invoke(newText);
 	}
 
 	public override void OnPluginMsgDirect(JsonObject jsonMsg)
@@ -273,7 +261,7 @@ public class NativeEditBox : PluginMsgReceiver
 		if (msg.Equals(MSG_TEXT_CHANGE))
 		{
 			string text = jsonMsg.GetString("text");
-			this.onTextChange(text);
+			this.updateUnityInputText(text);
 		}
 		else if (msg.Equals(MSG_TEXT_BEGIN_EDIT))
 		{
@@ -283,7 +271,7 @@ public class NativeEditBox : PluginMsgReceiver
 		else if (msg.Equals(MSG_TEXT_END_EDIT))
 		{
 			string text = jsonMsg.GetString("text");
-			this.onTextEditEnd(text);
+			this.updateUnityInputText(text);
 		}
 		else if (msg.Equals(MSG_RETURN_PRESSED))
 		{


### PR DESCRIPTION
`onValueChanged` event of the `InputField` is triggered twice on mobile platforms whenever the NativeEditBox receives a value changed message from native plugin. This PR adds new `OnValueChanged` event to `NativeEditBox` to be listened when the platform is mobile.