### PR TITLE
Add masked text support to Native Edit plugin [Android Only]

### DIFF
--- a/release/NativeEditPlugin/scripts/MaskOptions.cs
+++ b/release/NativeEditPlugin/scripts/MaskOptions.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Please see <see href="https://github.com/RedMadRobot/input-mask-android/wiki"/> for more information about
+/// the masks.
+/// </summary>
+public class MaskOptions
+{
+	public enum AffinityCalculationStrategy
+	{
+		Prefix = 0,
+		WholeString = 1,
+		Capacity = 2,
+		ExtractedValueCapacity = 3,
+	}
+
+	public string primaryMask { get; }
+	public IReadOnlyList<string> affineMasks { get; }
+	public AffinityCalculationStrategy affinityStrategy { get; }
+	public bool useCustomPlaceholder { get; }
+	public string customPlaceholder { get; }
+
+	public MaskOptions(
+		string primaryMask,
+		IReadOnlyList<string> affineMasks = null,
+		AffinityCalculationStrategy affinityStrategy = AffinityCalculationStrategy.Prefix,
+		bool useCustomPlaceholder = false,
+		string customPlaceholder = null)
+	{
+		this.primaryMask = primaryMask;
+		this.affineMasks = affineMasks;
+		this.affinityStrategy = affinityStrategy;
+		this.useCustomPlaceholder = useCustomPlaceholder;
+		this.customPlaceholder = customPlaceholder;
+	}
+}

--- a/release/NativeEditPlugin/scripts/MaskOptions.cs
+++ b/release/NativeEditPlugin/scripts/MaskOptions.cs
@@ -6,6 +6,15 @@ using System.Collections.Generic;
 /// </summary>
 public class MaskOptions
 {
+	/// <summary>
+	/// Strategy to calculate affinity value. For more information,
+	/// see <see href="https://github.com/RedMadRobot/input-mask-android/wiki"/>
+	/// </summary>
+	/// <remarks>
+	/// Integer value of this enum will be sent to the native side where it's
+	/// converted from int to related native enum value again.
+	/// On Android, EditBox.java does this conversion.
+	/// </remarks>
 	public enum AffinityCalculationStrategy
 	{
 		Prefix = 0,

--- a/release/NativeEditPlugin/scripts/MaskOptions.cs
+++ b/release/NativeEditPlugin/scripts/MaskOptions.cs
@@ -23,23 +23,41 @@ public class MaskOptions
 		ExtractedValueCapacity = 3,
 	}
 
-	public string primaryMask { get; }
-	public IReadOnlyList<string> affineMasks { get; }
-	public AffinityCalculationStrategy affinityStrategy { get; }
-	public bool useCustomPlaceholder { get; }
-	public string customPlaceholder { get; }
+	public string PrimaryMask { get; }
+	public IReadOnlyList<string> AffineMasks { get; }
+	public AffinityCalculationStrategy AffinityStrategy { get; }
+	public bool UseCustomPlaceholder { get; }
+	public string CustomPlaceholder { get; }
+	public string ExtraCharactersForDigits { get; }
 
+	/// <summary>
+	/// Creates new mask options.
+	/// </summary>
+	/// <param name="primaryMask">Primary mask to use.</param>
+	/// <param name="affineMasks">Affine masks to select depending on the given affinity strategy.</param>
+	/// <param name="affinityStrategy">Strategy to follow while selecting an affine mask.</param>
+	/// <param name="useCustomPlaceholder">Will be used to overwrite the placeholder of given mask.</param>
+	/// <param name="customPlaceholder">Placeholder to show instead of the default placeholder of given mask.</param>
+	/// <param name="extraCharactersForDigits">Can be used to set an extra accepted character set when
+	/// the content type is numbers only.</param>
+	/// <remarks>
+	/// If the content type is numbers only and there's a separation character in the mask (e.g space, dash etc.)
+	/// <see cref="ExtraCharactersForDigits"/> should be set to accept these characters. Otherwise an exception
+	/// will be thrown.
+	/// </remarks>
 	public MaskOptions(
 		string primaryMask,
 		IReadOnlyList<string> affineMasks = null,
 		AffinityCalculationStrategy affinityStrategy = AffinityCalculationStrategy.Prefix,
 		bool useCustomPlaceholder = false,
-		string customPlaceholder = null)
+		string customPlaceholder = null,
+		string extraCharactersForDigits = null)
 	{
-		this.primaryMask = primaryMask;
-		this.affineMasks = affineMasks;
-		this.affinityStrategy = affinityStrategy;
-		this.useCustomPlaceholder = useCustomPlaceholder;
-		this.customPlaceholder = customPlaceholder;
+		this.PrimaryMask = primaryMask;
+		this.AffineMasks = affineMasks;
+		this.AffinityStrategy = affinityStrategy;
+		this.UseCustomPlaceholder = useCustomPlaceholder;
+		this.CustomPlaceholder = customPlaceholder;
+		this.ExtraCharactersForDigits = extraCharactersForDigits;
 	}
 }

--- a/release/NativeEditPlugin/scripts/MaskOptions.cs.meta
+++ b/release/NativeEditPlugin/scripts/MaskOptions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5fb2f4de92464e218b1fedca464eb9c3
+timeCreated: 1565179309

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -1,3 +1,6 @@
+using System;
+using UnityEngine.UI;
+
 /// <summary>
 /// Formats the value depending on the given mask options.
 /// </summary>
@@ -14,6 +17,19 @@ public class MaskedNativeEditBox : NativeEditBox
 	private const string CustomPlaceholderKey = "customPlaceholder";
 
 	public MaskOptions MaskOptions { get; private set; }
+
+	/// <summary>
+	/// Event to call whenever the value changes. Will be called with the extracted value.
+	/// To get formatted values, listen <see cref="InputField.onValueChanged"/> event.
+	/// </summary>
+	public Action<string> OnValueChanged;
+
+	/// <summary>
+	/// Event to call when the editing has ended. Will be called with the extracted value.
+	/// To get formatted values, listen <see cref="InputField.onEndEdit"/> event.
+	/// </summary>
+	public Action<string> OnEndEdit;
+
 	private bool shouldApplyMask = true;
 
 	/// <summary>
@@ -38,5 +54,24 @@ public class MaskedNativeEditBox : NativeEditBox
 		jsonObject[AffinityStrategyKey] = (int)this.MaskOptions.affinityStrategy;
 		jsonObject[UseCustomPlaceholderKey] = this.MaskOptions.useCustomPlaceholder;
 		jsonObject[CustomPlaceholderKey] = this.MaskOptions.customPlaceholder;
+	}
+
+	protected override void HandlePluginMessage(JsonObject jsonMsg)
+	{
+		base.HandlePluginMessage(jsonMsg);
+
+		var msg = jsonMsg.GetString("msg");
+		if (msg.Equals(MSG_TEXT_CHANGE))
+		{
+			var extractedText = jsonMsg.GetString("extractedText");
+			if (this.OnValueChanged != null)
+				this.OnValueChanged(extractedText);
+		}
+		else if (msg.Equals(MSG_TEXT_END_EDIT))
+		{
+			var extractedText = jsonMsg.GetString("extractedText");
+			if (this.OnEndEdit != null)
+				this.OnEndEdit(extractedText);
+		}
 	}
 }

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using UnityEngine;
+
+/// <summary>
+/// Please see <see href="https://github.com/RedMadRobot/input-mask-android/wiki"/> for more information about
+/// the masks.
+/// </summary>
+public class MaskedNativeEditBox : NativeEditBox
+{
+	private enum AffinityCalculationStrategy
+	{
+		[UsedImplicitly] Prefix = 0,
+		[UsedImplicitly] WholeString = 1,
+		[UsedImplicitly] Capacity = 2,
+		[UsedImplicitly] ExtractedValueCapacity = 3,
+	}
+
+	[Header("Masked Text (Android Only)")]
+	[SerializeField] private string primaryMask;
+	[SerializeField] private List<string> affineMasks;
+	[SerializeField] private AffinityCalculationStrategy affinityStrategy;
+	[SerializeField] private bool useCustomPlaceholder;
+	[SerializeField] private string customPlaceholder;
+
+	protected override void AppendExtraFieldsForCreation(JsonObject jsonObject)
+	{
+		jsonObject["applyMask"] = true;
+		jsonObject["primaryMask"] = this.primaryMask;
+		jsonObject["affineMasks"] = this.affineMasks;
+		jsonObject["affinityStrategy"] = (int) this.affinityStrategy;
+		jsonObject["useCustomPlaceholder"] = this.useCustomPlaceholder;
+		jsonObject["customPlaceholder"] = this.customPlaceholder;
+	}
+}

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -1,35 +1,42 @@
-using System.Collections.Generic;
-using JetBrains.Annotations;
-using UnityEngine;
-
 /// <summary>
-/// Please see <see href="https://github.com/RedMadRobot/input-mask-android/wiki"/> for more information about
-/// the masks.
+/// Formats the value depending on the given mask options.
 /// </summary>
+/// <remarks>
+/// Works only on Android, iOS is not _yet_ supported.
+/// </remarks>
 public class MaskedNativeEditBox : NativeEditBox
 {
-	private enum AffinityCalculationStrategy
+	private const string ApplyMaskKey = "applyMask";
+	private const string PrimaryMaskKey = "primaryMask";
+	private const string AffineMasksKey = "affineMasks";
+	private const string AffinityStrategyKey = "affinityStrategy";
+	private const string UseCustomPlaceholderKey = "useCustomPlaceholder";
+	private const string CustomPlaceholderKey = "customPlaceholder";
+
+	public MaskOptions MaskOptions { get; private set; }
+	private bool shouldApplyMask = true;
+
+	/// <summary>
+	/// Please see <see href="https://github.com/RedMadRobot/input-mask-android/wiki"/> for more information about
+	/// the masks.
+	/// </summary>
+	public void SetMask(MaskOptions maskOptions)
 	{
-		[UsedImplicitly] Prefix = 0,
-		[UsedImplicitly] WholeString = 1,
-		[UsedImplicitly] Capacity = 2,
-		[UsedImplicitly] ExtractedValueCapacity = 3,
+		this.MaskOptions = maskOptions;
 	}
 
-	[Header("Masked Text (Android Only)")]
-	[SerializeField] private string primaryMask;
-	[SerializeField] private List<string> affineMasks;
-	[SerializeField] private AffinityCalculationStrategy affinityStrategy;
-	[SerializeField] private bool useCustomPlaceholder;
-	[SerializeField] private string customPlaceholder;
+	public void ApplyMask(bool to)
+	{
+		this.shouldApplyMask = to;
+	}
 
 	protected override void AppendExtraFieldsForCreation(JsonObject jsonObject)
 	{
-		jsonObject["applyMask"] = true;
-		jsonObject["primaryMask"] = this.primaryMask;
-		jsonObject["affineMasks"] = this.affineMasks;
-		jsonObject["affinityStrategy"] = (int) this.affinityStrategy;
-		jsonObject["useCustomPlaceholder"] = this.useCustomPlaceholder;
-		jsonObject["customPlaceholder"] = this.customPlaceholder;
+		jsonObject[ApplyMaskKey] = this.shouldApplyMask;
+		jsonObject[PrimaryMaskKey] = this.MaskOptions.primaryMask;
+		jsonObject[AffineMasksKey] = this.MaskOptions.affineMasks;
+		jsonObject[AffinityStrategyKey] = (int)this.MaskOptions.affinityStrategy;
+		jsonObject[UseCustomPlaceholderKey] = this.MaskOptions.useCustomPlaceholder;
+		jsonObject[CustomPlaceholderKey] = this.MaskOptions.customPlaceholder;
 	}
 }

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -49,6 +49,12 @@ public class MaskedNativeEditBox : NativeEditBox
 
 	protected override void AppendExtraFieldsForCreation(JsonObject jsonObject)
 	{
+		if (this.MaskOptions == null)
+		{
+			jsonObject[ApplyMaskKey] = false;
+			return;
+		}
+
 		jsonObject[ApplyMaskKey] = this.shouldApplyMask;
 		jsonObject[PrimaryMaskKey] = this.MaskOptions.primaryMask;
 		jsonObject[AffineMasksKey] = this.MaskOptions.affineMasks;

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -17,18 +17,19 @@ public class MaskedNativeEditBox : NativeEditBox
 	private const string CustomPlaceholderKey = "customPlaceholder";
 
 	public MaskOptions MaskOptions { get; private set; }
+	public string ExtractedText { get; private set; }
 
 	/// <summary>
 	/// Event to call whenever the value changes. Will be called with the extracted value.
 	/// To get formatted values, listen <see cref="InputField.onValueChanged"/> event.
 	/// </summary>
-	public Action<string> OnValueChanged;
+	public event Action<string> OnValueChanged;
 
 	/// <summary>
 	/// Event to call when the editing has ended. Will be called with the extracted value.
 	/// To get formatted values, listen <see cref="InputField.onEndEdit"/> event.
 	/// </summary>
-	public Action<string> OnEndEdit;
+	public event Action<string> OnEndEdit;
 
 	private bool shouldApplyMask = true;
 
@@ -63,15 +64,15 @@ public class MaskedNativeEditBox : NativeEditBox
 		var msg = jsonMsg.GetString("msg");
 		if (msg.Equals(MSG_TEXT_CHANGE))
 		{
-			var extractedText = jsonMsg.GetString("extractedText");
+			this.ExtractedText = jsonMsg.GetString("extractedText");
 			if (this.OnValueChanged != null)
-				this.OnValueChanged(extractedText);
+				this.OnValueChanged(this.ExtractedText);
 		}
 		else if (msg.Equals(MSG_TEXT_END_EDIT))
 		{
-			var extractedText = jsonMsg.GetString("extractedText");
+			this.ExtractedText = jsonMsg.GetString("extractedText");
 			if (this.OnEndEdit != null)
-				this.OnEndEdit(extractedText);
+				this.OnEndEdit(this.ExtractedText);
 		}
 	}
 }

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs
@@ -15,6 +15,7 @@ public class MaskedNativeEditBox : NativeEditBox
 	private const string AffinityStrategyKey = "affinityStrategy";
 	private const string UseCustomPlaceholderKey = "useCustomPlaceholder";
 	private const string CustomPlaceholderKey = "customPlaceholder";
+	private const string ExtraCharactersForDigitsKey = "extraCharactersForDigits";
 
 	public MaskOptions MaskOptions { get; private set; }
 	public string ExtractedText { get; private set; }
@@ -56,11 +57,12 @@ public class MaskedNativeEditBox : NativeEditBox
 		}
 
 		jsonObject[ApplyMaskKey] = this.shouldApplyMask;
-		jsonObject[PrimaryMaskKey] = this.MaskOptions.primaryMask;
-		jsonObject[AffineMasksKey] = this.MaskOptions.affineMasks;
-		jsonObject[AffinityStrategyKey] = (int)this.MaskOptions.affinityStrategy;
-		jsonObject[UseCustomPlaceholderKey] = this.MaskOptions.useCustomPlaceholder;
-		jsonObject[CustomPlaceholderKey] = this.MaskOptions.customPlaceholder;
+		jsonObject[PrimaryMaskKey] = this.MaskOptions.PrimaryMask;
+		jsonObject[AffineMasksKey] = this.MaskOptions.AffineMasks;
+		jsonObject[AffinityStrategyKey] = (int)this.MaskOptions.AffinityStrategy;
+		jsonObject[UseCustomPlaceholderKey] = this.MaskOptions.UseCustomPlaceholder;
+		jsonObject[CustomPlaceholderKey] = this.MaskOptions.CustomPlaceholder;
+		jsonObject[ExtraCharactersForDigitsKey] = this.MaskOptions.ExtraCharactersForDigits;
 	}
 
 	protected override void HandlePluginMessage(JsonObject jsonMsg)

--- a/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs.meta
+++ b/release/NativeEditPlugin/scripts/MaskedNativeEditBox.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e6e7a607a56e48af92ca597e1d8c068d
+timeCreated: 1565162931

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -96,6 +96,8 @@ public class NativeEditBox : PluginMsgReceiver
 	public InputField InputField { get { return objUnityInput; } }
 	public bool Visible { get; private set; }
 
+	protected virtual void AppendExtraFieldsForCreation(JsonObject jsonObject) { }
+
 	public string text
 	{
 		get { return objUnityInput.text; }
@@ -310,6 +312,7 @@ public class NativeEditBox : PluginMsgReceiver
 		jsonMsg["placeHolderColor_b"] = mConfig.placeHolderColor.b;
 		jsonMsg["placeHolderColor_a"] = mConfig.placeHolderColor.a;
 		jsonMsg["multiline"] = mConfig.multiline;
+		this.AppendExtraFieldsForCreation(jsonMsg);
 
 		switch (returnKeyType)
 		{

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -85,9 +85,9 @@ public class NativeEditBox : PluginMsgReceiver
 	private const string MSG_SET_TEXTSIZE = "SetTextSize";
 	private const string MSG_SET_FOCUS = "SetFocus";
 	private const string MSG_SET_VISIBLE = "SetVisible";
-	private const string MSG_TEXT_CHANGE = "TextChange";
+	protected const string MSG_TEXT_CHANGE = "TextChange";
 	private const string MSG_TEXT_BEGIN_EDIT = "TextBeginEdit";
-	private const string MSG_TEXT_END_EDIT = "TextEndEdit";
+	protected const string MSG_TEXT_END_EDIT = "TextEndEdit";
 	// to fix bug Some keys 'back' & 'enter' are eaten by unity and never arrive at plugin
 	private const string MSG_ANDROID_KEY_DOWN = "AndroidKeyDown";
 	private const string MSG_RETURN_PRESSED = "ReturnPressed";
@@ -241,14 +241,18 @@ public class NativeEditBox : PluginMsgReceiver
 
 	public override void OnPluginMsgDirect(JsonObject jsonMsg)
 	{
-		PluginMsgHandler.getInst().StartCoroutine(PluginsMessageRoutine(jsonMsg));
+		PluginMsgHandler.getInst().StartCoroutine(this.HandlePluginMessageOnNextFrame(jsonMsg));
 	}
 
-	private IEnumerator PluginsMessageRoutine(JsonObject jsonMsg)
+	private IEnumerator HandlePluginMessageOnNextFrame(JsonObject jsonMsg)
 	{
 		// this is to avoid a deadlock for more info when trying to get data from two separate native plugins and handling them in Unity
 		yield return null;
+		this.HandlePluginMessage(jsonMsg);
+	}
 
+	protected virtual void HandlePluginMessage(JsonObject jsonMsg)
+	{
 		string msg = jsonMsg.GetString("msg");
 		if (msg.Equals(MSG_TEXT_BEGIN_EDIT))
 		{

--- a/src/androidProj/nativeeditplugin/build.gradle
+++ b/src/androidProj/nativeeditplugin/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     provided files('./libs/UnityPlayer.jar')
     compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.redmadrobot:input-mask-android:4.3.1'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.41'
 }
 
 task clearJar(type: Delete) {

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -71,6 +71,9 @@ public class EditBox {
     private static final String MSG_ANDROID_KEY_DOWN = "AndroidKeyDown";
     private static final String MSG_RETURN_PRESSED = "ReturnPressed";
 
+    private static final String APPLY_MASK_KEY = "applyMask";
+    private static final String AFFINE_MASKS_KEY = "affineMasks";
+
     public static void processRecvJsonMsg(int nSenderId, final String strJson)
     {
         if (mapEditBox == null) mapEditBox = new SparseArray<>();
@@ -375,14 +378,11 @@ public class EditBox {
 
     private TextWatcher getEditTextWatcher(JSONObject jsonObj, final EditBox editBox) throws JSONException {
 
-        final String applyMaskKey = "applyMask";
-        final String affineMasksKey = "affineMasks";
-
-        boolean applyMask = jsonObj.has(applyMaskKey) && jsonObj.getBoolean(applyMaskKey);
+        boolean applyMask = jsonObj.has(APPLY_MASK_KEY) && jsonObj.getBoolean(APPLY_MASK_KEY);
 
         if (applyMask) {
             String primaryMask = jsonObj.getString("primaryMask");
-            JSONArray affineMasks = jsonObj.isNull(affineMasksKey) ? new JSONArray() : jsonObj.getJSONArray(affineMasksKey);
+            JSONArray affineMasks = jsonObj.isNull(AFFINE_MASKS_KEY) ? new JSONArray() : jsonObj.getJSONArray(AFFINE_MASKS_KEY);
             int affinityStrategy = jsonObj.getInt("affinityStrategy");
             boolean useCustomPlaceholder = jsonObj.getBoolean("useCustomPlaceholder");
             String customPlaceholder = jsonObj.getString("customPlaceholder");

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java
@@ -56,6 +56,8 @@ public class EditBox {
     private final RelativeLayout layout;
     private int tag;
     private int characterLimit;
+    private String extractedText = "";
+    private String formattedText = "";
 
     private static SparseArray<EditBox> mapEditBox = null;
     private static final String MSG_CREATE = "CreateEdit";
@@ -333,16 +335,7 @@ public class EditBox {
                 @Override
                 public void onFocusChange(View v, boolean hasFocus) {
 
-                    // your action here
-                    JSONObject msgTextEndJSON = new JSONObject();
-                    try
-                    {
-                        msgTextEndJSON.put("msg", hasFocus ? MSG_TEXT_BEGIN_EDIT : MSG_TEXT_END_EDIT);
-                        msgTextEndJSON.put("text", eb.GetText());
-                    }
-                    catch(JSONException e) {}
-                    eb.SendJsonToUnity(msgTextEndJSON);
-
+                    SendTextToUnity(hasFocus ? MSG_TEXT_BEGIN_EDIT : MSG_TEXT_END_EDIT);
                     SetFocus(hasFocus);
                 }
             });
@@ -407,7 +400,9 @@ public class EditBox {
                     new MaskedTextChangedListener.ValueListener() {
                         @Override
                         public void onTextChanged(boolean maskFilled, String extractedValue, String formattedValue) {
-                            editBox.SendTextToUnity(formattedValue);
+                            editBox.extractedText = extractedValue;
+                            editBox.formattedText = formattedValue;
+                            editBox.SendTextToUnity(MSG_TEXT_CHANGE);
                         }
                     });
 
@@ -429,7 +424,9 @@ public class EditBox {
                     edit.setText(s);
                     edit.setSelection(s.length());
                 }
-                SendTextToUnity(s.toString());
+                extractedText = s.toString();
+                formattedText = extractedText;
+                SendTextToUnity(MSG_TEXT_CHANGE);
             }
 
             @Override
@@ -439,13 +436,14 @@ public class EditBox {
         };
     }
 
-    private void SendTextToUnity(String text)
+    private void SendTextToUnity(String messageKey)
     {
         JSONObject jsonToUnity = new JSONObject();
         try
         {
-            jsonToUnity.put("msg", MSG_TEXT_CHANGE);
-            jsonToUnity.put("text", text);
+            jsonToUnity.put("msg", messageKey);
+            jsonToUnity.put("text", formattedText);
+            jsonToUnity.put("extractedText", extractedText);
         }
         catch(JSONException e) {}
         SendJsonToUnity(jsonToUnity);

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java.meta
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java.meta
@@ -5,14 +5,32 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
   - first:
       Android: Android
     second:
       enabled: 1
-      settings: {}
+      settings:
+        CPU: ARMv7
   - first:
       Any: 
     second:
@@ -23,7 +41,59 @@ PluginImporter:
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java.meta
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/EditBox.java.meta
@@ -1,0 +1,29 @@
+fileFormatVersion: 2
+guid: 2315322cc46b5475ebacc557c43c7ccc
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/NativeEditPlugin.java.meta
+++ b/src/androidProj/nativeeditplugin/src/main/java/com/bkmin/android/NativeEditPlugin.java.meta
@@ -1,0 +1,29 @@
+fileFormatVersion: 2
+guid: 7ce221fdcf4e949bdb24c027829930c7
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds support for masked texts using input-mask library **for Android**: https://github.com/RedMadRobot/input-mask-android, iOS support can also be added in future using the iOS version of the same plugin: https://github.com/RedMadRobot/input-mask-ios.