### PR TITLE
[YS-17440] Add support for custom keyboard type settings

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -247,6 +247,7 @@ bool approxEqualFloat(float x, float y)
     UIColor* placeHolderColor = [UIColor colorWithRed:placeHolderColor_r green:placeHolderColor_g blue:placeHolderColor_b alpha:placeHolderColor_a];
     
     NSString* contentType = [json getString:@"contentType"];
+    NSString* keyboardType = [json getString:@"keyboardType"];
     NSString* alignment = [json getString:@"align"];
     BOOL withDoneButton = [json getBool:@"withDoneButton"];
     BOOL multiline = [json getBool:@"multiline"];
@@ -259,35 +260,49 @@ bool approxEqualFloat(float x, float y)
     {
         autoCorr = YES;
     }
-    else if ([contentType isEqualToString:@"IntegerNumber"])
-    {
-        keyType = UIKeyboardTypeNumberPad;
-    }
-    else if ([contentType isEqualToString:@"DecimalNumber"])
-    {
-        keyType = UIKeyboardTypeDecimalPad;
-    }
-    else if ([contentType isEqualToString:@"Alphanumeric"])
-    {
-        keyType = UIKeyboardTypeAlphabet;
-    }
-    else if ([contentType isEqualToString:@"Name"])
-    {
-        keyType = UIKeyboardTypeNamePhonePad;
-    }
-    else if ([contentType isEqualToString:@"EmailAddress"])
-    {
-        keyType = UIKeyboardTypeEmailAddress;
-    }
     else if ([contentType isEqualToString:@"Password"])
     {
         password = YES;
     }
-    else if ([contentType isEqualToString:@"Pin"])
+
+    // We don't need to look at the content type to determine the keyboard type, as Unity InputField will fill in the right type.
+    if ([keyboardType isEqualToString:@"ASCIICapable"])
+    {
+        keyType = UIKeyboardTypeASCIICapable;
+    }
+    else if ([keyboardType isEqualToString:@"NumbersAndPunctuation"])
+    {
+        keyType = UIKeyboardTypeNumbersAndPunctuation;
+    }
+    else if ([keyboardType isEqualToString:@"URL"])
+    {
+        keyType = UIKeyboardTypeURL;
+    }
+    else if ([keyboardType isEqualToString:@"NumberPad"])
+    {
+        keyType = UIKeyboardTypeNumberPad;
+    }
+    else if ([keyboardType isEqualToString:@"PhonePad"])
     {
         keyType = UIKeyboardTypePhonePad;
     }
-    
+    else if ([keyboardType isEqualToString:@"NamePhonePad"])
+    {
+        keyType = UIKeyboardTypeNamePhonePad;
+    }
+    else if ([keyboardType isEqualToString:@"EmailAddress"])
+    {
+        keyType = UIKeyboardTypeEmailAddress;
+    }
+    else if ([keyboardType isEqualToString:@"Social"])
+    {
+        keyType = UIKeyboardTypeTwitter;
+    }
+    else if ([keyboardType isEqualToString:@"Search"])
+    {
+        keyType = UIKeyboardTypeWebSearch;
+    }
+
     UIControlContentHorizontalAlignment halign = UIControlContentHorizontalAlignmentLeft;
     UIControlContentVerticalAlignment valign = UIControlContentVerticalAlignmentCenter;
     

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -46,6 +46,7 @@ public class NativeEditBox : PluginMsgReceiver
 		public Color textColor;
 		public Color backColor;
 		public string contentType;
+		public string keyboardType;
 		public string font;
 		public float fontSize;
 		public string align;
@@ -235,6 +236,7 @@ public class NativeEditBox : PluginMsgReceiver
 		mConfig.textColor = objUnityText.color;
 		mConfig.align = objUnityText.alignment.ToString();
 		mConfig.contentType = objUnityInput.contentType.ToString();
+		mConfig.keyboardType = objUnityInput.keyboardType.ToString();
 		mConfig.backColor = new Color(1.0f, 1.0f, 1.0f, 0.0f);
 		mConfig.multiline = (objUnityInput.lineType == InputField.LineType.SingleLine) ? false : true;
 	}
@@ -308,6 +310,7 @@ public class NativeEditBox : PluginMsgReceiver
 		jsonMsg["font"] = mConfig.font;
 		jsonMsg["fontSize"] = mConfig.fontSize;
 		jsonMsg["contentType"] = mConfig.contentType;
+		jsonMsg["keyboardType"] = mConfig.keyboardType;
 		jsonMsg["align"] = mConfig.align;
 		jsonMsg["withDoneButton"] = this.withDoneButton;
 		jsonMsg["placeHolder"] = mConfig.placeHolder;


### PR DESCRIPTION
Unity InputField has a special "custom" ContentType that allows
finer-grained control over the keyboard and validation settings. This
content type wasn't properly supported by the plugin, as it never
communicated the custom keyboard type to the native side. This has
now been fixed.

Android native implementation already had handling for the custom
content type, so that was not modified. However, on iOS the keyboard
type was always set based on the content type. This code has now been
modified to take the Unity-determined keyboard type into use directly.
There we can rely on the fact that Unity InputField class already
determines the right keyboard to use in all cases.