### PR TITLE
(YS-18617) iOS content type override

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -422,17 +422,20 @@ bool approxEqualFloat(float x, float y)
         /// Todo
         /// UITextView Alignment is not implemented
 
-        if ([contentTypeOverride isEqualToString:@"Username"])
+        if (@available(iOS 12.0, *))
         {
-            textView.textContentType = UITextContentTypeUsername;
-        }
-        else if ([contentTypeOverride isEqualToString:@"Password"])
-        {
-            textView.textContentType = UITextContentTypePassword;
-        }
-        else if ([contentTypeOverride isEqualToString:@"NewPassword"])
-        {
-            textView.textContentType = UITextContentTypeNewPassword;
+            if ([contentTypeOverride isEqualToString:@"Username"])
+            {
+                textView.textContentType = UITextContentTypeUsername;
+            }
+            else if ([contentTypeOverride isEqualToString:@"Password"])
+            {
+                textView.textContentType = UITextContentTypePassword;
+            }
+            else if ([contentTypeOverride isEqualToString:@"NewPassword"])
+            {
+                textView.textContentType = UITextContentTypeNewPassword;
+            }
         }
         
         editView = textView;
@@ -461,17 +464,20 @@ bool approxEqualFloat(float x, float y)
         [textField setSecureTextEntry:password];
         if (keyboardDoneButtonView != nil) textField.inputAccessoryView = keyboardDoneButtonView;
 
-        if ([contentTypeOverride isEqualToString:@"Username"])
+        if (@available(iOS 12.0, *))
         {
-            textField.textContentType = UITextContentTypeUsername;
-        }
-        else if ([contentTypeOverride isEqualToString:@"Password"])
-        {
-            textField.textContentType = UITextContentTypePassword;
-        }
-        else if ([contentTypeOverride isEqualToString:@"NewPassword"])
-        {
-            textField.textContentType = UITextContentTypeNewPassword;
+            if ([contentTypeOverride isEqualToString:@"Username"])
+            {
+                textField.textContentType = UITextContentTypeUsername;
+            }
+            else if ([contentTypeOverride isEqualToString:@"Password"])
+            {
+                textField.textContentType = UITextContentTypePassword;
+            }
+            else if ([contentTypeOverride isEqualToString:@"NewPassword"])
+            {
+                textField.textContentType = UITextContentTypeNewPassword;
+            }
         }
 
         editView = textField;

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -251,6 +251,7 @@ bool approxEqualFloat(float x, float y)
     NSString* alignment = [json getString:@"align"];
     BOOL withDoneButton = [json getBool:@"withDoneButton"];
     BOOL multiline = [json getBool:@"multiline"];
+    NSString* contentTypeOverride = [json getString:@"contentTypeOverride"];
     
     BOOL autoCorr = NO;
     BOOL password = NO;
@@ -417,10 +418,22 @@ bool approxEqualFloat(float x, float y)
         
         [textView setSecureTextEntry:password];
         if (keyboardDoneButtonView != nil) textView.inputAccessoryView = keyboardDoneButtonView;
-        
-        
+
         /// Todo
         /// UITextView Alignment is not implemented
+
+        if ([contentTypeOverride isEqualToString:@"Username"])
+        {
+            textView.textContentType = UITextContentTypeUsername;
+        }
+        else if ([contentTypeOverride isEqualToString:@"Password"])
+        {
+            textView.textContentType = UITextContentTypePassword;
+        }
+        else if ([contentTypeOverride isEqualToString:@"NewPassword"])
+        {
+            textView.textContentType = UITextContentTypeNewPassword;
+        }
         
         editView = textView;
     }
@@ -447,7 +460,20 @@ bool approxEqualFloat(float x, float y)
         [textField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
         [textField setSecureTextEntry:password];
         if (keyboardDoneButtonView != nil) textField.inputAccessoryView = keyboardDoneButtonView;
-        
+
+        if ([contentTypeOverride isEqualToString:@"Username"])
+        {
+            textField.textContentType = UITextContentTypeUsername;
+        }
+        else if ([contentTypeOverride isEqualToString:@"Password"])
+        {
+            textField.textContentType = UITextContentTypePassword;
+        }
+        else if ([contentTypeOverride isEqualToString:@"NewPassword"])
+        {
+            textField.textContentType = UITextContentTypeNewPassword;
+        }
+
         editView = textField;
     }
     [viewPlugin addSubview:editView];

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -392,7 +392,7 @@ bool approxEqualFloat(float x, float y)
         uiFont = [UIFont systemFontOfSize:fontSize];
     }
 
-    UITextContentType* contentType = nil;
+    UITextContentType contentType = nil;
     if (@available(iOS 12.0, *))
     {
         if ([contentTypeOverride isEqualToString:@"Username"])

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -392,7 +392,7 @@ bool approxEqualFloat(float x, float y)
         uiFont = [UIFont systemFontOfSize:fontSize];
     }
 
-    NSString* contentType;
+    UITextContentType* contentType = nil;
     if (@available(iOS 12.0, *))
     {
         if ([contentTypeOverride isEqualToString:@"Username"])

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -251,7 +251,7 @@ bool approxEqualFloat(float x, float y)
     NSString* alignment = [json getString:@"align"];
     BOOL withDoneButton = [json getBool:@"withDoneButton"];
     BOOL multiline = [json getBool:@"multiline"];
-    NSString* contentTypeOverride = [json getString:@"contentTypeOverride"];
+    NSString* contentTypeOverride = [json getString:@"iosContentTypeOverride"];
     
     BOOL autoCorr = NO;
     BOOL password = NO;
@@ -390,8 +390,25 @@ bool approxEqualFloat(float x, float y)
     else
     {
         uiFont = [UIFont systemFontOfSize:fontSize];
-    }    
-    
+    }
+
+    NSString* contentType;
+    if (@available(iOS 12.0, *))
+    {
+        if ([contentTypeOverride isEqualToString:@"Username"])
+        {
+            contentType = UITextContentTypeUsername;
+        }
+        else if ([contentTypeOverride isEqualToString:@"Password"])
+        {
+            contentType = UITextContentTypePassword;
+        }
+        else if ([contentTypeOverride isEqualToString:@"NewPassword"])
+        {
+            contentType = UITextContentTypeNewPassword;
+        }
+    }
+
     if (multiline)
     {
         PlaceholderTextView* textView = [[PlaceholderTextView alloc] initWithFrame:CGRectMake(x, y, width, height)];
@@ -422,20 +439,9 @@ bool approxEqualFloat(float x, float y)
         /// Todo
         /// UITextView Alignment is not implemented
 
-        if (@available(iOS 12.0, *))
+        if (contentType != nil)
         {
-            if ([contentTypeOverride isEqualToString:@"Username"])
-            {
-                textView.textContentType = UITextContentTypeUsername;
-            }
-            else if ([contentTypeOverride isEqualToString:@"Password"])
-            {
-                textView.textContentType = UITextContentTypePassword;
-            }
-            else if ([contentTypeOverride isEqualToString:@"NewPassword"])
-            {
-                textView.textContentType = UITextContentTypeNewPassword;
-            }
+            textView.textContentType = contentType;
         }
         
         editView = textView;
@@ -464,20 +470,9 @@ bool approxEqualFloat(float x, float y)
         [textField setSecureTextEntry:password];
         if (keyboardDoneButtonView != nil) textField.inputAccessoryView = keyboardDoneButtonView;
 
-        if (@available(iOS 12.0, *))
+        if (contentType != nil)
         {
-            if ([contentTypeOverride isEqualToString:@"Username"])
-            {
-                textField.textContentType = UITextContentTypeUsername;
-            }
-            else if ([contentTypeOverride isEqualToString:@"Password"])
-            {
-                textField.textContentType = UITextContentTypePassword;
-            }
-            else if ([contentTypeOverride isEqualToString:@"NewPassword"])
-            {
-                textField.textContentType = UITextContentTypeNewPassword;
-            }
+            textField.textContentType = contentType;
         }
 
         editView = textField;

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -392,20 +392,20 @@ bool approxEqualFloat(float x, float y)
         uiFont = [UIFont systemFontOfSize:fontSize];
     }
 
-    UITextContentType contentType = nil;
+    UITextContentType overrideContentType = nil;
     if (@available(iOS 12.0, *))
     {
         if ([contentTypeOverride isEqualToString:@"Username"])
         {
-            contentType = UITextContentTypeUsername;
+            overrideContentType = UITextContentTypeUsername;
         }
         else if ([contentTypeOverride isEqualToString:@"Password"])
         {
-            contentType = UITextContentTypePassword;
+            overrideContentType = UITextContentTypePassword;
         }
         else if ([contentTypeOverride isEqualToString:@"NewPassword"])
         {
-            contentType = UITextContentTypeNewPassword;
+            overrideContentType = UITextContentTypeNewPassword;
         }
     }
 
@@ -439,9 +439,9 @@ bool approxEqualFloat(float x, float y)
         /// Todo
         /// UITextView Alignment is not implemented
 
-        if (contentType != nil)
+        if (overrideContentType != nil)
         {
-            textView.textContentType = contentType;
+            textView.textContentType = overrideContentType;
         }
         
         editView = textView;
@@ -470,9 +470,9 @@ bool approxEqualFloat(float x, float y)
         [textField setSecureTextEntry:password];
         if (keyboardDoneButtonView != nil) textField.inputAccessoryView = keyboardDoneButtonView;
 
-        if (contentType != nil)
+        if (overrideContentType != nil)
         {
-            textField.textContentType = contentType;
+            textField.textContentType = overrideContentType;
         }
 
         editView = textField;

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -53,6 +53,7 @@ public class NativeEditBox : PluginMsgReceiver
 		public string placeHolder;
 		public int characterLimit;
 		public Color placeHolderColor;
+		public IosContentTypeOverride iosContentTypeOverride;
 	}
 
 	public enum ReturnKeyType
@@ -61,9 +62,18 @@ public class NativeEditBox : PluginMsgReceiver
 		Next,
 		Done
 	}
-		
+
+	private enum IosContentTypeOverride
+	{
+		None,
+		Username,
+		Password,
+		NewPassword,
+	}
+
 	public bool	withDoneButton = true;
 	public ReturnKeyType returnKeyType;
+	[SerializeField] private IosContentTypeOverride iosContentTypeOverride;
 
 	public event Action returnPressed;
 
@@ -239,6 +249,7 @@ public class NativeEditBox : PluginMsgReceiver
 		mConfig.keyboardType = objUnityInput.keyboardType.ToString();
 		mConfig.backColor = new Color(1.0f, 1.0f, 1.0f, 0.0f);
 		mConfig.multiline = (objUnityInput.lineType == InputField.LineType.SingleLine) ? false : true;
+		this.mConfig.iosContentTypeOverride = this.iosContentTypeOverride;
 	}
 
 	public override void OnPluginMsgDirect(JsonObject jsonMsg)
@@ -319,6 +330,7 @@ public class NativeEditBox : PluginMsgReceiver
 		jsonMsg["placeHolderColor_b"] = mConfig.placeHolderColor.b;
 		jsonMsg["placeHolderColor_a"] = mConfig.placeHolderColor.a;
 		jsonMsg["multiline"] = mConfig.multiline;
+		jsonMsg["contentTypeOverride"] = this.mConfig.iosContentTypeOverride.ToString();
 		this.AppendExtraFieldsForCreation(jsonMsg);
 
 		switch (returnKeyType)

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -63,6 +63,7 @@ public class NativeEditBox : PluginMsgReceiver
 		Done
 	}
 
+	// The name of these enum values has to exactly match the string check in iOS native code
 	private enum IosContentTypeOverride
 	{
 		None,
@@ -330,7 +331,7 @@ public class NativeEditBox : PluginMsgReceiver
 		jsonMsg["placeHolderColor_b"] = mConfig.placeHolderColor.b;
 		jsonMsg["placeHolderColor_a"] = mConfig.placeHolderColor.a;
 		jsonMsg["multiline"] = mConfig.multiline;
-		jsonMsg["contentTypeOverride"] = this.mConfig.iosContentTypeOverride.ToString();
+		jsonMsg["iosContentTypeOverride"] = this.mConfig.iosContentTypeOverride.ToString();
 		this.AppendExtraFieldsForCreation(jsonMsg);
 
 		switch (returnKeyType)


### PR DESCRIPTION
We want to start using iOS keychain strong password suggestion and password autofill properly. To do that we need support for iOS native text field content types. This PR opens up a new field in NativeEditBox component that allows us to override the content type.