### PR TITLE
Autofill related fixes

### DIFF
--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -478,12 +478,8 @@ bool approxEqualFloat(float x, float y)
         editView = textField;
     }
     [viewPlugin addSubview:editView];
-
-    if (overrideContentType != nil && overrideContentType != UITextContentTypeNewPassword)
-    {
-        [editView becomeFirstResponder];
-        [editView resignFirstResponder];
-    }
+    [editView becomeFirstResponder];
+    [editView resignFirstResponder];
 }
 
 -(void) setText:(JsonObject*)json

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -478,8 +478,12 @@ bool approxEqualFloat(float x, float y)
         editView = textField;
     }
     [viewPlugin addSubview:editView];
-    [editView becomeFirstResponder];
-    [editView resignFirstResponder];
+
+    if (overrideContentType != nil && overrideContentType != UITextContentTypeNewPassword)
+    {
+        [editView becomeFirstResponder];
+        [editView resignFirstResponder];
+    }
 }
 
 -(void) setText:(JsonObject*)json

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -478,8 +478,6 @@ bool approxEqualFloat(float x, float y)
         editView = textField;
     }
     [viewPlugin addSubview:editView];
-    [editView becomeFirstResponder];
-    [editView resignFirstResponder];
 }
 
 -(void) setText:(JsonObject*)json

--- a/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
+++ b/release/NativeEditPlugin/Plugins/iOS/EditBox_iOS.m
@@ -478,6 +478,8 @@ bool approxEqualFloat(float x, float y)
         editView = textField;
     }
     [viewPlugin addSubview:editView];
+    [editView becomeFirstResponder];
+    [editView resignFirstResponder];
 }
 
 -(void) setText:(JsonObject*)json

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -194,14 +194,6 @@ public class NativeEditBox : PluginMsgReceiver
 		base.OnDestroy();
 	}
 
-	private void OnApplicationFocus(bool hasFocus)
-	{
-		if (!bNativeEditCreated || !this.Visible)
-			return;
-
-		this.SetVisible(hasFocus);
-	}
-
 	private IEnumerator InitializeOnNextFrame()
 	{
 		yield return null;

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -207,6 +207,12 @@ public class NativeEditBox : PluginMsgReceiver
 		objUnityText.enabled = false;
 		objUnityInput.enabled = false;
 
+		// For iOS autofill to work correctly, all input fields expected to be autofilled, need to exist before we set
+		// the native focus. Assuming all related input fields are created simultaneously, they will all be
+		// initialized after one frame (see above). In this case, waiting for one more frame should ensure they all
+		// exist before we set the focus. In more complex cases, the caller may need to further delay setting focus,
+		// until all related input fields are guaranteed to exist.
+
 		yield return null;
 
 		if (this.focusOnCreate)

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -347,8 +347,10 @@ public class NativeEditBox : PluginMsgReceiver
 		if (!visibleOnCreate)
 			SetVisible(false);
 
-		if (focusOnCreate)
-			SetFocus(true);
+		if (this.focusOnCreate)
+		{
+			this.StartCoroutine(this.DelayedFocus(true));
+		}
 	}
 
 	private void SetTextNative(string newText)
@@ -391,6 +393,13 @@ public class NativeEditBox : PluginMsgReceiver
 			this.SendPluginMsg(sizeMsg);
 			this.mConfig.fontSize = fontSize;
 		}
+	}
+
+	private IEnumerator DelayedFocus(bool focus)
+	{
+		yield return null;
+
+		this.SetFocus(focus);
 	}
 
 	public void SetFocus(bool bFocus)

--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -206,6 +206,13 @@ public class NativeEditBox : PluginMsgReceiver
 		objUnityInput.placeholder.gameObject.SetActive(false);
 		objUnityText.enabled = false;
 		objUnityInput.enabled = false;
+
+		yield return null;
+
+		if (this.focusOnCreate)
+		{
+			this.SetFocus(true);
+		}
 		#endif
 	}
 
@@ -346,11 +353,6 @@ public class NativeEditBox : PluginMsgReceiver
 
 		if (!visibleOnCreate)
 			SetVisible(false);
-
-		if (this.focusOnCreate)
-		{
-			this.StartCoroutine(this.DelayedFocus(true));
-		}
 	}
 
 	private void SetTextNative(string newText)
@@ -393,13 +395,6 @@ public class NativeEditBox : PluginMsgReceiver
 			this.SendPluginMsg(sizeMsg);
 			this.mConfig.fontSize = fontSize;
 		}
-	}
-
-	private IEnumerator DelayedFocus(bool focus)
-	{
-		yield return null;
-
-		this.SetFocus(focus);
 	}
 
 	public void SetFocus(bool bFocus)


### PR DESCRIPTION
Two main changes:

1. Stop hiding and showing native input fields when our app loses/gains focus. This was messing up autofill and disconnecting open keyboard from focused input field.
2. Delay setting focus to an input field when it's created. Setting focus before all fields are created on native level breaks autofill.