### PR TITLE
Fix for NullReferenceException when TextEndEdit is sent

### DIFF
--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -289,6 +289,10 @@ public class NativeEditBox : PluginMsgReceiver
 
 	protected virtual void HandlePluginMessage(JsonObject jsonMsg)
 	{
+		// By the time this is called the component might be destroyed
+		if (this == null)
+			return;
+
 		string msg = jsonMsg.GetString("msg");
 		if (msg.Equals(MSG_TEXT_BEGIN_EDIT))
 		{


### PR DESCRIPTION
The HandlePluginMessage call is delayed by a single frame using PluginMsgHandler. By the time it's called, the component can be destroyed.